### PR TITLE
Improves calling simli api for Nuxt and Next environments

### DIFF
--- a/lib/SimliClient.ts
+++ b/lib/SimliClient.ts
@@ -164,8 +164,9 @@ class SimliClient {
 
     public async getIceServers(apiKey: string, SimliURL: string, attempt = 1): Promise<RTCIceServer[]> {
         try {
+            const url = `http${SimliURL}/getIceServers`;
             const response: any = await Promise.race([
-                fetch(`http${SimliURL}/getIceServers`, {
+                fetch(url, {
                     headers: { "Content-Type": "application/json" },
                     method: "POST",
                     body: JSON.stringify({ apiKey: apiKey }),
@@ -283,7 +284,8 @@ class SimliClient {
                 this.handleConnectionTimeout();
             }, this.CONNECTION_TIMEOUT_MS)
 
-            const ws = new WebSocket(`ws${this.SimliURL}/StartWebRTCSession`);
+            const url = `ws${this.SimliURL}/StartWebRTCSession`;
+            const ws = new WebSocket(url);
             this.webSocket = ws;
             const wsConnectPromise = new Promise<void>((resolve) => {
                 if (!this.webSocket) {
@@ -406,8 +408,9 @@ class SimliClient {
     public async createSessionToken(SimliURL: string, metadata: SimliSessionRequest): Promise<SimliSessionToken> {
         if (this.session_token && this.session_token !== "") { return { session_token: this.session_token } }
         try {
+            const url = `http${SimliURL}/startAudioToVideoSession`;
             const response = await fetch(
-                `http${SimliURL}/startAudioToVideoSession`,
+                url,
                 {
                     method: "POST",
                     body: JSON.stringify(metadata),


### PR DESCRIPTION
# 🛠 Fix: URL Concatenation for Fetch & WebSocket in SimliClient

Both Nuxt and Next.js clients are breaking due to how simli-client currently concatenates URLs directly inside fetch() and WebSocket() calls. These SSR frameworks try to "help" by prepending their own server URLs, resulting in malformed paths like:

```
http://localhost:3000/http/startAudioToVideoSession
```
😱 Yeah. That happened.

## 🧠 What Happened?

Over the weekend (with far too many hours and too little sleep), I investigated why both Nuxt and Next.js apps struggle with simli-client. Here's the core of the issue:

```js
const ws = new WebSocket(`ws${this.SimliURL}/StartWebRTCSession`);
```
When SimliURL is an empty string ("") or unresolved, the resulting string is interpreted by Nuxt/Next as a relative path — and they attempt to SSR it. Boom. Broken.

## ✅ Proposed Fix

Refactor how SimliURL is handled:
Store the final, resolved URL string before using it in fetch() or new WebSocket().
This makes the framework happy, avoids SSR path rewriting, and stabilizes behavior across environments.

For example:

```js
const wsUrl = `ws${this.SimliURL}/StartWebRTCSession`;
const ws = new WebSocket(wsUrl);
```

This works consistently across frameworks and it doesn't even break anything.

## 🔥 Why This Matters
- React: Inconsistent. Sometimes works, then suddenly doesn't on reload.
- Vue (Nuxt): Consistently tells you you're wrong — returns SSR HTML instead of hitting Simli.
- Dev sanity: Almost lost mine. You can save others. 🙏